### PR TITLE
Localization and German translation

### DIFF
--- a/PasteIntoFile/PasteIntoFile.csproj
+++ b/PasteIntoFile/PasteIntoFile.csproj
@@ -64,6 +64,7 @@
     <EmbeddedResource Include="frmMain.resx">
       <DependentUpon>frmMain.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.de.resx" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/PasteIntoFile/Program.cs
+++ b/PasteIntoFile/Program.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using PasteIntoFile.Properties;
 
 namespace PasteAsFile
 {
@@ -54,12 +55,12 @@ namespace PasteAsFile
                 key = key.CreateSubKey("filename");
                 key.SetValue("", filename);
 
-                MessageBox.Show("Filename has been registered with your system", "Paste Into File", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(Resources.str_message_register_filename_success, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 			}
 			catch (Exception ex)
 			{
 				//throw;
-				MessageBox.Show(ex.Message + "\nPlease run the application as Administrator !", "Paste As File", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				MessageBox.Show(ex.Message + "\n" + Resources.str_message_run_as_admin, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 		}
 
@@ -73,12 +74,12 @@ namespace PasteAsFile
 				key = OpenDirectoryKey().OpenSubKey("shell", true);
 				key.DeleteSubKeyTree("Paste Into File");
 
-				MessageBox.Show("Application has been Unregistered from your system", "Paste Into File", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				MessageBox.Show(Resources.str_message_unregister_context_menu_success, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
 			}
 			catch (Exception ex)
 			{
-				MessageBox.Show(ex.Message + "\nPlease run the application as Administrator !", "Paste Into File", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				MessageBox.Show(ex.Message + "\n" + Resources.str_message_run_as_admin, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Error);
 				
 			}
 		}
@@ -96,13 +97,13 @@ namespace PasteAsFile
 				key.SetValue("Icon", "\"" + Application.ExecutablePath + "\",0");
 				key = key.CreateSubKey("command");
 				key.SetValue("" , "\"" + Application.ExecutablePath + "\" \"%1\"");
-				MessageBox.Show("Application has been registered with your system", "Paste Into File", MessageBoxButtons.OK, MessageBoxIcon.Information);
+				MessageBox.Show(Resources.str_message_register_context_menu_success, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
 			}
 			catch (Exception ex)
 			{
 				//throw;
-				MessageBox.Show(ex.Message + "\nPlease run the application as Administrator !", "Paste As File", MessageBoxButtons.OK, MessageBoxIcon.Error);
+				MessageBox.Show(ex.Message + "\n" + Resources.str_message_run_as_admin, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 		}
 

--- a/PasteIntoFile/Program.cs
+++ b/PasteIntoFile/Program.cs
@@ -11,6 +11,8 @@ namespace PasteAsFile
 {
 	static class Program
 	{
+		public static readonly string RegistrySubKey = "Paste Into File";
+
 		/// <summary>
 		/// The main entry point for the application.
 		/// </summary>
@@ -51,7 +53,7 @@ namespace PasteAsFile
 		{
 			try
 			{
-                var key = OpenDirectoryKey().CreateSubKey("shell").CreateSubKey("Paste Into File");
+                var key = OpenDirectoryKey().CreateSubKey("shell").CreateSubKey(RegistrySubKey);
                 key = key.CreateSubKey("filename");
                 key.SetValue("", filename);
 
@@ -69,10 +71,10 @@ namespace PasteAsFile
 			try
 			{
 				var key = OpenDirectoryKey().OpenSubKey(@"Background\shell", true);
-				key.DeleteSubKeyTree("Paste Into File");
+				key.DeleteSubKeyTree(RegistrySubKey);
 
 				key = OpenDirectoryKey().OpenSubKey("shell", true);
-				key.DeleteSubKeyTree("Paste Into File");
+				key.DeleteSubKeyTree(RegistrySubKey);
 
 				MessageBox.Show(Resources.str_message_unregister_context_menu_success, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
@@ -88,12 +90,14 @@ namespace PasteAsFile
 		{
 			try
 			{
-				var key = OpenDirectoryKey().CreateSubKey(@"Background\shell").CreateSubKey("Paste Into File");
+				var key = OpenDirectoryKey().CreateSubKey(@"Background\shell").CreateSubKey(RegistrySubKey);
+				key.SetValue("", Resources.explorer_context_entry);
 				key.SetValue("Icon", "\"" + Application.ExecutablePath + "\",0");
 				key = key.CreateSubKey("command");
 				key.SetValue("" , "\"" + Application.ExecutablePath + "\" \"%V\"");
 
-				key = OpenDirectoryKey().CreateSubKey("shell").CreateSubKey("Paste Into File");
+				key = OpenDirectoryKey().CreateSubKey("shell").CreateSubKey(RegistrySubKey);
+				key.SetValue("", Resources.explorer_context_entry);
 				key.SetValue("Icon", "\"" + Application.ExecutablePath + "\",0");
 				key = key.CreateSubKey("command");
 				key.SetValue("" , "\"" + Application.ExecutablePath + "\" \"%1\"");

--- a/PasteIntoFile/Properties/Resources.Designer.cs
+++ b/PasteIntoFile/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace PasteIntoFile.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,180 @@ namespace PasteIntoFile.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paste Into File.
+        /// </summary>
+        internal static string explorer_context_entry {
+            get {
+                return ResourceManager.GetString("explorer_context_entry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ….
+        /// </summary>
+        internal static string str_ellipsis {
+            get {
+                return ResourceManager.GetString("str_ellipsis", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Extension.
+        /// </summary>
+        internal static string str_extension {
+            get {
+                return ResourceManager.GetString("str_extension", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File saved :).
+        /// </summary>
+        internal static string str_file_saved {
+            get {
+                return ResourceManager.GetString("str_file_saved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filename.
+        /// </summary>
+        internal static string str_filename {
+            get {
+                return ResourceManager.GetString("str_filename", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Current Location.
+        /// </summary>
+        internal static string str_location {
+            get {
+                return ResourceManager.GetString("str_location", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to It seems that you are running this application for the first time,
+        ///do you want to add an entry to the explorer context menu?.
+        /// </summary>
+        internal static string str_message_first_time {
+            get {
+                return ResourceManager.GetString("str_message_first_time", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paste Into File helps you paste any text or images in your system clipboard into a file directly instead of creating new file yourself
+        ///      
+        ///--------------------
+        ///      
+        ///To Register the application to your system context menu run the program as administrator with this argument : /reg
+        ///to Unregister the application use this argument : /unreg
+        ///To change the format of the default filename, use this argument: /filename yyyy-MM-dd_HHmm
+        ///
+        ///--------------------
+        ///
+        ///https://github.com/EslaMx7/PasteIntoFile
+        ///Send [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string str_message_help {
+            get {
+                return ResourceManager.GetString("str_message_help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Explorer context menu entry has been added.
+        /// </summary>
+        internal static string str_message_register_context_menu_success {
+            get {
+                return ResourceManager.GetString("str_message_register_context_menu_success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filename-template has been registered.
+        /// </summary>
+        internal static string str_message_register_filename_success {
+            get {
+                return ResourceManager.GetString("str_message_register_filename_success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please run the application as Administrator!.
+        /// </summary>
+        internal static string str_message_run_as_admin {
+            get {
+                return ResourceManager.GetString("str_message_run_as_admin", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Explorer context menu entry has been removed.
+        /// </summary>
+        internal static string str_message_unregister_context_menu_success {
+            get {
+                return ResourceManager.GetString("str_message_unregister_context_menu_success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Save.
+        /// </summary>
+        internal static string str_save {
+            get {
+                return ResourceManager.GetString("str_save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select a folder for saving this file .
+        /// </summary>
+        internal static string str_select_folder {
+            get {
+                return ResourceManager.GetString("str_select_folder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image file.
+        /// </summary>
+        internal static string str_type_img {
+            get {
+                return ResourceManager.GetString("str_type_img", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text file.
+        /// </summary>
+        internal static string str_type_txt {
+            get {
+                return ResourceManager.GetString("str_type_txt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown file.
+        /// </summary>
+        internal static string str_type_unknown {
+            get {
+                return ResourceManager.GetString("str_type_unknown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paste Into File.
+        /// </summary>
+        internal static string window_title {
+            get {
+                return ResourceManager.GetString("window_title", resourceCulture);
             }
         }
     }

--- a/PasteIntoFile/Properties/Resources.de.resx
+++ b/PasteIntoFile/Properties/Resources.de.resx
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<root>
+    <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+        <xsd:element name="root" msdata:IsDataSet="true">
+            
+        </xsd:element>
+    </xsd:schema>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>1.3</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <data name="str_save" xml:space="preserve">
+        <value>Speichern</value>
+    </data>
+    <data name="str_message_register_filename_success" xml:space="preserve">
+        <value>Dateiname-Vorlage wurde registriert</value>
+    </data>
+    <data name="str_filename" xml:space="preserve">
+        <value>Dateiname</value>
+    </data>
+    <data name="str_extension" xml:space="preserve">
+        <value>Erweiterung</value>
+    </data>
+    <data name="str_file_saved" xml:space="preserve">
+        <value>Gespeichert :)</value>
+    </data>
+    <data name="str_message_first_time" xml:space="preserve">
+        <value>Es scheint als würdest du die Anwendung zum ersten Mal starten. Möchtest du einen Eintrag zum Kontextmenu des Explorers hinzufügen?</value>
+    </data>
+    <data name="str_location" xml:space="preserve">
+        <value>Speicherort</value>
+    </data>
+    <data name="str_select_folder" xml:space="preserve">
+        <value>Speicherort auswählen</value>
+    </data>
+    <data name="str_type_img" xml:space="preserve">
+        <value>Bilddatei</value>
+    </data>
+    <data name="str_type_txt" xml:space="preserve">
+        <value>Textdatei</value>
+    </data>
+    <data name="str_type_unknown" xml:space="preserve">
+        <value>Unbekannte Datei</value>
+    </data>
+    <data name="str_message_register_context_menu_success" xml:space="preserve">
+        <value>Eintrag im Kontextmenu wurde hinzugefügt</value>
+    </data>
+    <data name="str_message_run_as_admin" xml:space="preserve">
+        <value>Bitte die Anwendung als Administrator ausführen!</value>
+    </data>
+    <data name="str_message_unregister_context_menu_success" xml:space="preserve">
+        <value>Eintrag im Kontextmenu wurde entfernt</value>
+    </data>
+    <data name="explorer_context_entry" xml:space="preserve">
+        <value>Einfügen als Datei (Paste Into File)</value>
+    </data>
+    <data name="str_message_help" xml:space="preserve">
+        <value>Paste Into File speichert Texte und Bilder aus der Zwischenablage direkt als Datei.
+      
+--------------------
+
+Komandozeilen-Argumente:
+ /reg           	Fügt den Eintrag dem Kontextmenu hinzu
+ /unreg         	Entfernt den Eintrag aus dem Kontextmenu
+ /filename XXX  	Stellt den Standard Dateinamen ein,
+                	z.B. yyyy-MM-dd_HHmm
+
+--------------------
+
+https://github.com/EslaMx7/PasteIntoFile
+Feedback an: eslamx7@gmail.com
+Danke :)</value>
+    </data>
+</root>

--- a/PasteIntoFile/Properties/Resources.resx
+++ b/PasteIntoFile/Properties/Resources.resx
@@ -114,4 +114,71 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="str_message_register_filename_success" xml:space="preserve">
+    <value>Filename-template has been registered</value>
+  </data>
+  <data name="str_save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="str_filename" xml:space="preserve">
+    <value>Filename</value>
+  </data>
+  <data name="str_extension" xml:space="preserve">
+    <value>Extension</value>
+  </data>
+  <data name="str_location" xml:space="preserve">
+    <value>Current Location</value>
+  </data>
+  <data name="str_ellipsis" xml:space="preserve">
+    <value>…</value>
+  </data>
+  <data name="window_title" xml:space="preserve">
+    <value>Paste Into File</value>
+  </data>
+  <data name="str_message_unregister_context_menu_success" xml:space="preserve">
+    <value>Explorer context menu entry has been removed</value>
+  </data>
+  <data name="str_message_run_as_admin" xml:space="preserve">
+    <value>Please run the application as Administrator!</value>
+  </data>
+  <data name="str_message_register_context_menu_success" xml:space="preserve">
+    <value>Explorer context menu entry has been added</value>
+  </data>
+  <data name="explorer_context_entry" xml:space="preserve">
+    <value>Paste Into File</value>
+  </data>
+  <data name="str_message_first_time" xml:space="preserve">
+    <value>It seems that you are running this application for the first time,
+do you want to add an entry to the explorer context menu?</value>
+  </data>
+  <data name="str_type_txt" xml:space="preserve">
+    <value>Text file</value>
+  </data>
+  <data name="str_type_img" xml:space="preserve">
+    <value>Image file</value>
+  </data>
+  <data name="str_type_unknown" xml:space="preserve">
+    <value>Unknown file</value>
+  </data>
+  <data name="str_file_saved" xml:space="preserve">
+    <value>File saved :)</value>
+  </data>
+  <data name="str_select_folder" xml:space="preserve">
+    <value>Select a folder for saving this file </value>
+  </data>
+  <data name="str_message_help" xml:space="preserve">
+    <value>Paste Into File helps you paste any text or images in your system clipboard into a file directly instead of creating new file yourself
+      
+--------------------
+      
+To Register the application to your system context menu run the program as administrator with this argument : /reg
+to Unregister the application use this argument : /unreg
+To change the format of the default filename, use this argument: /filename yyyy-MM-dd_HHmm
+
+--------------------
+
+https://github.com/EslaMx7/PasteIntoFile
+Send Feedback to: eslamx7@gmail.com
+Thanks :)</value>
+  </data>
 </root>

--- a/PasteIntoFile/frmMain.Designer.cs
+++ b/PasteIntoFile/frmMain.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace PasteAsFile
+﻿using PasteIntoFile.Properties;
+
+namespace PasteAsFile
 {
     partial class frmMain
     {
@@ -83,7 +85,7 @@
             this.lblFileName.Name = "lblFileName";
             this.lblFileName.Size = new System.Drawing.Size(73, 17);
             this.lblFileName.TabIndex = 4;
-            this.lblFileName.Text = "Filename :";
+            this.lblFileName.Text = Resources.str_filename;
             // 
             // txtFilename
             // 
@@ -102,7 +104,7 @@
             this.lblExt.Name = "lblExt";
             this.lblExt.Size = new System.Drawing.Size(77, 17);
             this.lblExt.TabIndex = 6;
-            this.lblExt.Text = "Extension :";
+            this.lblExt.Text = Resources.str_extension;
             // 
             // comExt
             // 
@@ -137,7 +139,7 @@
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(180, 37);
             this.btnSave.TabIndex = 5;
-            this.btnSave.Text = "Save";
+            this.btnSave.Text = Resources.str_save;
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
             // 
@@ -158,7 +160,7 @@
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(121, 17);
             this.label1.TabIndex = 9;
-            this.label1.Text = "Current Location :";
+            this.label1.Text = Resources.str_location;
             // 
             // btnBrowseForFolder
             // 
@@ -167,7 +169,7 @@
             this.btnBrowseForFolder.Name = "btnBrowseForFolder";
             this.btnBrowseForFolder.Size = new System.Drawing.Size(44, 28);
             this.btnBrowseForFolder.TabIndex = 4;
-            this.btnBrowseForFolder.Text = "...";
+            this.btnBrowseForFolder.Text = Resources.str_ellipsis;
             this.btnBrowseForFolder.UseVisualStyleBackColor = true;
             this.btnBrowseForFolder.Click += new System.EventHandler(this.btnBrowseForFolder_Click);
             // 
@@ -233,7 +235,7 @@
             this.MaximizeBox = false;
             this.Name = "frmMain";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Paste Into File";
+            this.Text = Resources.window_title;
             this.Load += new System.EventHandler(this.frmMain_Load);
             ((System.ComponentModel.ISupportInitialize)(this.imgContent)).EndInit();
             this.ResumeLayout(false);

--- a/PasteIntoFile/frmMain.cs
+++ b/PasteIntoFile/frmMain.cs
@@ -32,11 +32,11 @@ namespace PasteAsFile
         }
         private void frmMain_Load(object sender, EventArgs e)
         {
-            string filename = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\shell\Paste Into File\filename", "", null) ?? DEFAULT_FILENAME_FORMAT;
+            string filename = (string)Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\shell\"+Program.RegistrySubKey+@"\filename", "", null) ?? DEFAULT_FILENAME_FORMAT;
             txtFilename.Text = DateTime.Now.ToString(filename);
             txtCurrentLocation.Text = CurrentLocation ?? @"C:\";
 
-            if (Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Paste Into File\command", "", null) == null)
+            if (Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\"+Program.RegistrySubKey+@"\command", "", null) == null)
             {
                 if (MessageBox.Show(Resources.str_message_first_time, Resources.window_title, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {

--- a/PasteIntoFile/frmMain.cs
+++ b/PasteIntoFile/frmMain.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using PasteIntoFile.Properties;
 
 namespace PasteAsFile
 {
@@ -37,7 +38,7 @@ namespace PasteAsFile
 
             if (Registry.GetValue(@"HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Paste Into File\command", "", null) == null)
             {
-                if (MessageBox.Show("Seems that you are running this application for the first time,\nDo you want to Register it with your system Context Menu ?", "Paste Into File", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                if (MessageBox.Show(Resources.str_message_first_time, Resources.window_title, MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
                 {
                     Program.RegisterApp();
                 }
@@ -45,7 +46,7 @@ namespace PasteAsFile
 
             if (Clipboard.ContainsText())
             {
-                lblType.Text = "Text File";
+                lblType.Text = Resources.str_type_txt;
                 comExt.SelectedItem = "txt";
                 IsText = true;
                 txtContent.Text = Clipboard.GetText();
@@ -54,13 +55,13 @@ namespace PasteAsFile
 
             if (Clipboard.ContainsImage())
             {
-                lblType.Text = "Image";
+                lblType.Text = Resources.str_type_img;
                 comExt.SelectedItem = "png";
                 imgContent.Image = Clipboard.GetImage();
                 return;
             }
 
-            lblType.Text = "Unknown File";
+            lblType.Text = Resources.str_type_unknown;
             btnSave.Enabled = false;
 
 
@@ -75,7 +76,6 @@ namespace PasteAsFile
             {
 
                 File.WriteAllText(location + filename, txtContent.Text, Encoding.UTF8);
-                this.Text += " : File Saved :)";
             }
             else
             {
@@ -101,8 +101,9 @@ namespace PasteAsFile
                         break;
                 }
 
-                this.Text += " : Image Saved :)";
             }
+            
+            this.btnSave.Text = Resources.str_file_saved;
 
             Task.Factory.StartNew(() =>
             {
@@ -114,7 +115,7 @@ namespace PasteAsFile
         private void btnBrowseForFolder_Click(object sender, EventArgs e)
         {
             FolderBrowserDialog fbd = new FolderBrowserDialog();
-            fbd.Description = "Select a folder for saving this file ";
+            fbd.Description = Resources.str_select_folder;
             if (fbd.ShowDialog() == DialogResult.OK)
             {
                 txtCurrentLocation.Text = fbd.SelectedPath;
@@ -133,12 +134,7 @@ namespace PasteAsFile
 
         private void lblHelp_Click(object sender, EventArgs e)
         {
-            string msg = "Paste Into File helps you paste any text or images in your system clipboard into a file directly instead of creating new file yourself";
-            msg += "\n--------------------\nTo Register the application to your system Context Menu run the program as Administrator with this argument : /reg";
-            msg += "\nto Unregister the application use this argument : /unreg\n";
-            msg += "\nTo change the format of the default filename, use this argument: /filename yyyy-MM-dd_HHmm\n";
-            msg += "\n--------------------\nSend Feedback to : eslamx7@gmail.com\n\nThanks :)";
-            MessageBox.Show(msg, "Paste As File Help", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            MessageBox.Show(Resources.str_message_help, Resources.window_title, MessageBoxButtons.OK, MessageBoxIcon.Information);
 
 
 


### PR DESCRIPTION
Hard coded Strings have been moved to the resource file `Resources.resx`, allowing to create localized resource files. German translation has been added. Further translations can now simply be added by creating an additional resource file `Resources.XX.resx` where XX is the ISO 639 language code.

-----------
Here are some screenshots for different system language settings:

| EN (default) | DE |
|-|-|
| ![screenshot-gb](https://user-images.githubusercontent.com/19860638/91136254-8e0aec80-e6ae-11ea-85e8-796b41e74a6e.png) | ![screenshot](https://user-images.githubusercontent.com/19860638/91131142-18eae780-e6ad-11ea-9b39-21c003e208fb.png) 
| ![screenshot2-gb](https://user-images.githubusercontent.com/19860638/91136260-8ea38300-e6ae-11ea-93c4-05e47e282114.png) | ![screenshot2](https://user-images.githubusercontent.com/19860638/91131140-18525100-e6ad-11ea-950c-657784db1b28.png)
| ![screenshot3-gb](https://user-images.githubusercontent.com/19860638/91136244-8d725600-e6ae-11ea-8478-4ed751f3bc5a.png) | ![screenshot3](https://user-images.githubusercontent.com/19860638/91131145-19837e00-e6ad-11ea-9bf6-94ba752322b6.png)


